### PR TITLE
fix: error cause param

### DIFF
--- a/errors.d.ts
+++ b/errors.d.ts
@@ -3,12 +3,15 @@ interface InitializationError extends LevelUPError { }
 interface OpenError extends LevelUPError { }
 interface ReadError extends LevelUPError { }
 interface WriteError extends LevelUPError { }
-interface NotFoundError extends Error { }
+interface NotFoundError extends Error {
+  notFound: any;
+  status: any;
+}
 interface EncodingError extends LevelUPError { }
 
 interface LevelUPErrorConstructor<TError> {
-  new(message?: string): TError;
-  (message?: string): TError;
+  new(message?: string, cause?: any): TError;
+  (message?: string, cause?: any): TError;
   readonly prototype: TError;
 }
 


### PR DESCRIPTION
Sorry, should have used these typings locally with levelup's typings. 
Should be okay with a patch? 