### PR TITLE
Don't wrap existing errors

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -29,14 +29,11 @@ function createError (type, Proto) {
     }
   }
 
-  if (Proto != null) {
-    Err.prototype = new Proto()
-  }
-
+  Err.prototype = new Proto()
   return Err
 }
 
-const LevelUPError = createError('LevelUPError')
+const LevelUPError = createError('LevelUPError', Error)
 
 module.exports = {
   LevelUPError: LevelUPError,

--- a/errors.js
+++ b/errors.js
@@ -8,10 +8,10 @@ function createError (type, Proto) {
       message = message.message || message.name
     }
 
-    Object.defineProperty(this, 'type', { value: type, enumerable: false, writable: false, configurable: false })
-    Object.defineProperty(this, 'name', { value: type, enumerable: false, writable: false, configurable: false })
-    Object.defineProperty(this, 'cause', { value: cause, enumerable: false, writable: false, configurable: false })
-    Object.defineProperty(this, 'message', { value: message || '', enumerable: false, writable: false, configurable: false })
+    Object.defineProperty(this, 'type', { value: type, enumerable: false, writable: true, configurable: true })
+    Object.defineProperty(this, 'name', { value: type, enumerable: false, writable: true, configurable: true })
+    Object.defineProperty(this, 'cause', { value: cause, enumerable: false, writable: true, configurable: true })
+    Object.defineProperty(this, 'message', { value: message || '', enumerable: false, writable: true, configurable: true })
 
     Error.call(this)
 

--- a/errors.js
+++ b/errors.js
@@ -2,16 +2,25 @@
 
 function createError (type, Proto) {
   const Err = function (message, cause) {
-    if (message && typeof message !== 'string') {
+    if (typeof message === 'object' && message !== null) {
       // Can be passed just a cause
       cause = cause || message
       message = message.message || message.name
     }
 
+    message = message || ''
+    cause = cause || undefined
+
+    // If input is already of type, return as-is to keep its stack trace.
+    // Avoid instanceof, for when node_modules has multiple copies of level-errors.
+    if (typeof cause === 'object' && cause.type === type && cause.message === message) {
+      return cause
+    }
+
     Object.defineProperty(this, 'type', { value: type, enumerable: false, writable: true, configurable: true })
     Object.defineProperty(this, 'name', { value: type, enumerable: false, writable: true, configurable: true })
     Object.defineProperty(this, 'cause', { value: cause, enumerable: false, writable: true, configurable: true })
-    Object.defineProperty(this, 'message', { value: message || '', enumerable: false, writable: true, configurable: true })
+    Object.defineProperty(this, 'message', { value: message, enumerable: false, writable: true, configurable: true })
 
     Error.call(this)
 

--- a/errors.js
+++ b/errors.js
@@ -3,16 +3,15 @@
 function createError (type, Proto) {
   const Err = function (message, cause) {
     if (message && typeof message !== 'string') {
+      // Can be passed just a cause
+      cause = cause || message
       message = message.message || message.name
     }
-
-    // can be passed just a 'cause'
-    cause = typeof message !== 'string' ? message : cause
 
     Object.defineProperty(this, 'type', { value: type, enumerable: false, writable: false, configurable: false })
     Object.defineProperty(this, 'name', { value: type, enumerable: false, writable: false, configurable: false })
     Object.defineProperty(this, 'cause', { value: cause, enumerable: false, writable: false, configurable: false })
-    Object.defineProperty(this, 'message', { value: message, enumerable: false, writable: false, configurable: false })
+    Object.defineProperty(this, 'message', { value: message || '', enumerable: false, writable: false, configurable: false })
 
     Error.call(this)
 

--- a/errors.js
+++ b/errors.js
@@ -1,11 +1,34 @@
 'use strict'
 
-const createError = require('errno').create
-const LevelUPError = createError('LevelUPError')
-const NotFoundError = createError('NotFoundError', LevelUPError)
+function createError (type, Proto) {
+  const Err = function (message, cause) {
+    if (message && typeof message !== 'string') {
+      message = message.message || message.name
+    }
 
-NotFoundError.prototype.notFound = true
-NotFoundError.prototype.status = 404
+    // can be passed just a 'cause'
+    cause = typeof message !== 'string' ? message : cause
+
+    Object.defineProperty(this, 'type', { value: type, enumerable: false, writable: false, configurable: false })
+    Object.defineProperty(this, 'name', { value: type, enumerable: false, writable: false, configurable: false })
+    Object.defineProperty(this, 'cause', { value: cause, enumerable: false, writable: false, configurable: false })
+    Object.defineProperty(this, 'message', { value: message, enumerable: false, writable: false, configurable: false })
+
+    Error.call(this)
+
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, Err)
+    }
+  }
+
+  if (Proto != null) {
+    Err.prototype = new Proto()
+  }
+
+  return Err
+}
+
+const LevelUPError = createError('LevelUPError')
 
 module.exports = {
   LevelUPError: LevelUPError,
@@ -13,6 +36,9 @@ module.exports = {
   OpenError: createError('OpenError', LevelUPError),
   ReadError: createError('ReadError', LevelUPError),
   WriteError: createError('WriteError', LevelUPError),
-  NotFoundError: NotFoundError,
+  NotFoundError: createError('NotFoundError', LevelUPError),
   EncodingError: createError('EncodingError', LevelUPError)
 }
+
+module.exports.NotFoundError.prototype.notFound = true
+module.exports.NotFoundError.prototype.status = 404

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "LICENSE.md",
     "UPGRADING.md"
   ],
-  "dependencies": {
-    "errno": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "airtap": "^4.0.3",
     "airtap-playwright": "^1.0.1",

--- a/test.js
+++ b/test.js
@@ -64,7 +64,7 @@ test('NotFoundError has special properties', function (t) {
   t.end()
 })
 
-test('error message is writable for flexibility', function (t) {
+test('error message is writable to mirror node core conventions', function (t) {
   const error = new errors.WriteError('foo')
   error.message = 'Got error: ' + error.message
   t.is(error.message, 'Got error: foo')

--- a/test.js
+++ b/test.js
@@ -3,11 +3,12 @@
 const test = require('tape')
 const errors = require('.')
 
-test('all errors are instances of LevelUPError', function (t) {
+test('all errors are instances of Error and LevelUPError', function (t) {
   const LevelUPError = errors.LevelUPError
   const keys = Object.keys(errors)
 
   keys.forEach(function (key) {
+    t.ok(new errors[key]() instanceof Error)
     t.ok(new errors[key]() instanceof LevelUPError)
   })
 

--- a/test.js
+++ b/test.js
@@ -63,12 +63,7 @@ test('NotFoundError has special properties', function (t) {
   t.end()
 })
 
-test.skip('error message is writable', function (t) {
-  // TODO: bug in prr? Given shorthand 'ewr', the effective options are:
-  // { enumerable: false, configurable: false, writable: false }
-  // Let's keep enumerable as-is, but set configurable and writable for flexibility.
-  // That's also the same as the `message` property of a new Error('foo').
-
+test('error message is writable for flexibility', function (t) {
   const error = new errors.WriteError('foo')
   error.message = 'Got error: ' + error.message
   t.is(error.message, 'Got error: foo')

--- a/test.js
+++ b/test.js
@@ -14,9 +14,63 @@ test('all errors are instances of LevelUPError', function (t) {
   t.end()
 })
 
+test('error with message has expected properties', function (t) {
+  const error = new errors.ReadError('foo')
+
+  t.is(error.type, 'ReadError')
+  t.is(error.name, 'ReadError')
+  t.is(error.cause, undefined)
+  t.is(error.message, 'foo')
+  t.end()
+})
+
+test('error without message has expected properties', function (t) {
+  const error = new errors.ReadError()
+
+  t.is(error.type, 'ReadError')
+  t.is(error.name, 'ReadError')
+  t.is(error.cause, undefined)
+  // t.is(error.message, '') // TODO: bug
+  t.end()
+})
+
+test('error with cause has expected properties', function (t) {
+  const cause = new Error('foo')
+  const error = new errors.ReadError(cause)
+
+  t.is(error.type, 'ReadError')
+  t.is(error.name, 'ReadError')
+  // t.ok(error.cause === cause) // TODO: bug in errno
+  t.is(error.message, 'foo')
+  t.end()
+})
+
+test('error with message and cause has expected properties', function (t) {
+  const cause = new Error('foo')
+  const error = new errors.ReadError('bar', cause)
+
+  t.is(error.type, 'ReadError')
+  t.is(error.name, 'ReadError')
+  t.ok(error.cause === cause)
+  t.is(error.message, 'bar')
+  t.end()
+})
+
 test('NotFoundError has special properties', function (t) {
   const error = new errors.NotFoundError()
-  t.equal(error.notFound, true)
-  t.equal(error.status, 404)
+  t.is(error.notFound, true)
+  t.is(error.status, 404)
+  t.end()
+})
+
+test.skip('error message is writable', function (t) {
+  // TODO: bug in prr? Given shorthand 'ewr', the effective options are:
+  // { enumerable: false, configurable: false, writable: false }
+  // Let's keep enumerable as-is, but set configurable and writable for flexibility.
+  // That's also the same as the `message` property of a new Error('foo').
+
+  const error = new errors.WriteError('foo')
+  error.message = 'Got error: ' + error.message
+  t.is(error.message, 'Got error: foo')
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -69,3 +69,33 @@ test('error message is writable for flexibility', function (t) {
   t.is(error.message, 'Got error: foo')
   t.end()
 })
+
+test('returns original instance if cause is the same type', function (t) {
+  const cause = new errors.NotFoundError('Key not found in database [foo]')
+  const error = new errors.NotFoundError(cause)
+  t.ok(cause === error, 'same instance')
+  t.is(error.message, 'Key not found in database [foo]')
+  t.end()
+})
+
+test('returns new instance if cause prototype is different', function (t) {
+  const cause = new errors.NotFoundError('Key not found in database [foo]')
+  const error = new errors.WriteError(cause)
+  t.ok(cause !== error, 'new instance')
+  t.is(error.message, 'Key not found in database [foo]')
+  t.end()
+})
+
+test('returns original instance if message and cause are the same', function (t) {
+  const cause = new errors.NotFoundError('Key not found in database [foo]')
+  const error = new errors.NotFoundError('Key not found in database [foo]', cause)
+  t.ok(cause === error, 'same instance')
+  t.end()
+})
+
+test('returns new instance if message is different', function (t) {
+  const cause = new errors.NotFoundError('Key not found in database [foo]')
+  const error = new errors.NotFoundError('Key not found in database [bar]', cause)
+  t.ok(cause !== error, 'new instance')
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ test('error with cause has expected properties', function (t) {
 
   t.is(error.type, 'ReadError')
   t.is(error.name, 'ReadError')
-  t.ok(error.cause === cause)
+  t.is(error.cause, cause)
   t.is(error.message, 'foo')
   t.end()
 })
@@ -52,7 +52,7 @@ test('error with message and cause has expected properties', function (t) {
 
   t.is(error.type, 'ReadError')
   t.is(error.name, 'ReadError')
-  t.ok(error.cause === cause)
+  t.is(error.cause, cause)
   t.is(error.message, 'bar')
   t.end()
 })
@@ -74,7 +74,7 @@ test('error message is writable for flexibility', function (t) {
 test('returns original instance if cause is the same type', function (t) {
   const cause = new errors.NotFoundError('Key not found in database [foo]')
   const error = new errors.NotFoundError(cause)
-  t.ok(cause === error, 'same instance')
+  t.is(cause, error, 'same instance')
   t.is(error.message, 'Key not found in database [foo]')
   t.end()
 })
@@ -82,7 +82,7 @@ test('returns original instance if cause is the same type', function (t) {
 test('returns new instance if cause prototype is different', function (t) {
   const cause = new errors.NotFoundError('Key not found in database [foo]')
   const error = new errors.WriteError(cause)
-  t.ok(cause !== error, 'new instance')
+  t.isNot(cause, error, 'new instance')
   t.is(error.message, 'Key not found in database [foo]')
   t.end()
 })
@@ -90,13 +90,13 @@ test('returns new instance if cause prototype is different', function (t) {
 test('returns original instance if message and cause are the same', function (t) {
   const cause = new errors.NotFoundError('Key not found in database [foo]')
   const error = new errors.NotFoundError('Key not found in database [foo]', cause)
-  t.ok(cause === error, 'same instance')
+  t.is(cause, error, 'same instance')
   t.end()
 })
 
 test('returns new instance if message is different', function (t) {
   const cause = new errors.NotFoundError('Key not found in database [foo]')
   const error = new errors.NotFoundError('Key not found in database [bar]', cause)
-  t.ok(cause !== error, 'new instance')
+  t.isNot(cause, error, 'new instance')
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ test('error without message has expected properties', function (t) {
   t.is(error.type, 'ReadError')
   t.is(error.name, 'ReadError')
   t.is(error.cause, undefined)
-  // t.is(error.message, '') // TODO: bug
+  t.is(error.message, '')
   t.end()
 })
 
@@ -40,7 +40,7 @@ test('error with cause has expected properties', function (t) {
 
   t.is(error.type, 'ReadError')
   t.is(error.name, 'ReadError')
-  // t.ok(error.cause === cause) // TODO: bug in errno
+  t.ok(error.cause === cause)
   t.is(error.message, 'foo')
   t.end()
 })


### PR DESCRIPTION
So that when `abstract-leveldown` starts using `level-errors`, and such a db is wrapped with `levelup`, `levelup` will not rewrap
errors and lose stack trace information in the process. I.e.:

```js
// Error created by abstract-leveldown
const err = new ReadError('example')

// Error created by levelup
const wrapped = new ReadError(err)

assert(wrapped === err)
```

Initially I wanted to do this in [`errno`](https://github.com/rvagg/node-errno), but I want more flexibility than what would be right for `errno`, specifically, comparing errors by their `.type` instead of with `instanceof`. In addition, I found some bugs in `errno` and [`prr`](https://github.com/rvagg/prr), of which the latter is archived, so I figured inlining (a subset of `errno`) would be easier. Also results in less code overall. To see those bugs, review this PR commit by commit.

There's technically a breaking change here: errors are no longer an instanceof [CustomError](https://github.com/rvagg/node-errno/blob/26ac1f13acb97044ef071a21fee6aa983bf96fe3/custom.js#L16-L24), but I consider that an internal detail.

Ref Level/community#58.